### PR TITLE
Add interlocking surface change API to Renderer for wayland

### DIFF
--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -52,6 +52,23 @@ void Host::SetRenderHandle(void* handle, int width, int height)
   }
 }
 
+void Host::BlockForSurfaceDestroy()
+{
+  if (g_renderer)
+    g_renderer->BlockHostForSurfaceDestroy();
+}
+
+void Host::UnblockWithNewSurface(void* surface, int width, int height)
+{
+  m_render_handle = surface;
+  if (g_renderer)
+  {
+    g_renderer->UnblockRendererWithNewSurface(surface, width, height);
+    if (g_controller_interface.IsInit())
+      g_controller_interface.ChangeWindow(surface, width, height);
+  }
+}
+
 bool Host::GetRenderFocus()
 {
   return m_render_focus;

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -24,6 +24,8 @@ public:
   bool GetRenderFullscreen();
 
   void SetRenderHandle(void* handle, int width, int height);
+  void BlockForSurfaceDestroy();
+  void UnblockWithNewSurface(void* surface, int width, int height);
   void SetRenderFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
   void ResizeSurface(int new_width, int new_height);

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -7,6 +7,8 @@
 #include <QMainWindow>
 #include <QStringList>
 
+#include "Common/WindowSystemInfo.h"
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -193,6 +195,7 @@ private:
   std::unique_ptr<X11Utils::XRRConfiguration> m_xrr_config;
 #endif
 
+  WindowSystemType m_wsi_type;
   QProgressDialog* m_progress_dialog = nullptr;
   QStackedWidget* m_stack;
   ToolBar* m_tool_bar;

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -7,6 +7,8 @@
 #include <QEvent>
 #include <QWidget>
 
+#include "Common/WindowSystemInfo.h"
+
 class QMouseEvent;
 class QTimer;
 
@@ -15,7 +17,7 @@ class RenderWidget final : public QWidget
   Q_OBJECT
 
 public:
-  explicit RenderWidget(QWidget* parent = nullptr);
+  explicit RenderWidget(WindowSystemType wsi_type, QWidget* parent = nullptr);
 
   bool event(QEvent* event) override;
   void showFullScreen();
@@ -27,6 +29,8 @@ signals:
   void EscapePressed();
   void Closed();
   void HandleChanged(void* handle, int new_width, int new_height);
+  void SurfaceAboutToBeDestroyed();
+  void SurfaceCreated(void* handle, int new_width, int new_height);
   void StateChanged(bool fullscreen);
   void SizeChanged(int new_width, int new_height);
   void FocusChanged(bool focus);
@@ -44,4 +48,5 @@ private:
   static constexpr int MOUSE_HIDE_DELAY = 3000;
   QTimer* m_mouse_timer;
   QPoint m_last_mouse{};
+  WindowSystemType m_wsi_type;
 };

--- a/Source/Core/InputCommon/ControllerInterface/Wayland/Wayland.h
+++ b/Source/Core/InputCommon/ControllerInterface/Wayland/Wayland.h
@@ -66,7 +66,7 @@ private:
   {
   public:
     std::string GetName() const override { return m_name; }
-    bool IsDetectable() override { return false; }
+    bool IsDetectable() const override { return false; }
     Cursor(u8 index, bool positive, const float* cursor);
     ControlState GetState() const override;
 
@@ -81,7 +81,7 @@ private:
   {
   public:
     std::string GetName() const override { return m_name; }
-    bool IsDetectable() override { return false; }
+    bool IsDetectable() const override { return false; }
     Axis(u8 index, bool positive, const float* axis);
     ControlState GetState() const override;
 

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -17,6 +17,8 @@
 #include "VideoBackends/Vulkan/VKTexture.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
+#include "VideoCommon/RenderBase.h"
+
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 #include <X11/Xlib.h>
 #endif
@@ -562,6 +564,11 @@ bool SwapChain::RecreateSurface(void* native_handle, int window_width, int windo
   DestroySwapChainImages();
   DestroySwapChain();
   DestroySurface();
+
+  // If passed handle is null (Wayland), use the interlock to mutually synchronize host and
+  // renderer.
+  if (native_handle == nullptr)
+    std::tie(native_handle, window_width, window_height) = g_renderer->WaitForNewSurface();
 
   // Re-create the surface with the new native handle
   m_wsi.render_surface = native_handle;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -206,7 +206,7 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
 #endif
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
   if (wstype == WindowSystemType::Wayland &&
-      !SupportsExtension(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME, true))
+      !AddExtension(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME, true))
   {
     return false;
   }

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(videocommon
   ShaderGenCommon.h
   Statistics.cpp
   Statistics.h
+  SurfaceChangeInterlock.cpp
+  SurfaceChangeInterlock.h
   TextureCacheBase.cpp
   TextureCacheBase.h
   TextureConfig.cpp

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -627,6 +627,25 @@ void Renderer::ChangeSurface(void* new_surface_handle, int new_width, int new_he
   m_surface_changed.Set();
 }
 
+void Renderer::BlockHostForSurfaceDestroy()
+{
+  m_new_surface_handle = nullptr;
+  m_surface_changed.Set();
+  m_surface_change_interlock.BlockHostForSurfaceDestroy();
+}
+
+void Renderer::UnblockRendererWithNewSurface(void* new_surface_handle, int new_width,
+                                             int new_height)
+{
+  m_surface_change_interlock.UnblockRendererWithNewSurface(new_surface_handle, new_width,
+                                                           new_height);
+}
+
+std::tuple<void*, int, int> Renderer::WaitForNewSurface()
+{
+  return m_surface_change_interlock.WaitForNewSurface();
+}
+
 void Renderer::ResizeSurface(int new_width, int new_height)
 {
   std::lock_guard<std::mutex> lock(m_swap_mutex);

--- a/Source/Core/VideoCommon/SurfaceChangeInterlock.cpp
+++ b/Source/Core/VideoCommon/SurfaceChangeInterlock.cpp
@@ -1,0 +1,37 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/SurfaceChangeInterlock.h"
+
+#include "Common/Assert.h"
+
+void SurfaceChangeInterlock::BlockHostForSurfaceDestroy()
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  DEBUG_ASSERT(m_state == State::NotBlocking);
+  m_state = State::BlockingHost;
+  m_host_cv.wait(lock);
+}
+
+void SurfaceChangeInterlock::UnblockRendererWithNewSurface(void* native_handle, int width,
+                                                           int height)
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  DEBUG_ASSERT(m_state == State::BlockingRenderer);
+  m_native_handle = native_handle;
+  m_width = width;
+  m_height = height;
+  m_renderer_cv.notify_one();
+}
+
+std::tuple<void*, int, int> SurfaceChangeInterlock::WaitForNewSurface()
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  DEBUG_ASSERT(m_state == State::BlockingHost);
+  m_host_cv.notify_one();
+  m_state = State::BlockingRenderer;
+  m_renderer_cv.wait(lock);
+  m_state = State::NotBlocking;
+  return {m_native_handle, m_width, m_height};
+}

--- a/Source/Core/VideoCommon/SurfaceChangeInterlock.h
+++ b/Source/Core/VideoCommon/SurfaceChangeInterlock.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+// ---------------------------------------------------------------------------------------------
+// Stateful interlock for synchronizing surface changes between host and renderer threads.
+// It first blocks the host thread until the rendering surface can be safely destroyed.
+// Then it blocks the rendering thread until the host comes back with a new surface.
+//
+// Designed to work with Wayland platform, but can be used for any platform that depends
+// on synchronous surface changes.
+// ---------------------------------------------------------------------------------------------
+
+#include <condition_variable>
+#include <mutex>
+
+class SurfaceChangeInterlock
+{
+  enum class State
+  {
+    NotBlocking,
+    BlockingHost,
+    BlockingRenderer
+  };
+
+public:
+  void BlockHostForSurfaceDestroy();
+  void UnblockRendererWithNewSurface(void* native_handle, int width, int height);
+  std::tuple<void*, int, int> WaitForNewSurface();
+
+private:
+  std::mutex m_mutex;
+  std::condition_variable m_host_cv;
+  std::condition_variable m_renderer_cv;
+  void* m_native_handle = nullptr;
+  int m_width = 0, m_height = 0;
+  State m_state = State::NotBlocking;
+};

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -87,6 +87,7 @@
     <ClCompile Include="UberShaderCommon.cpp" />
     <ClCompile Include="UberShaderPixel.cpp" />
     <ClCompile Include="Statistics.cpp" />
+    <ClCompile Include="SurfaceChangeInterlock.cpp" />
     <ClCompile Include="GeometryShaderGen.cpp" />
     <ClCompile Include="GeometryShaderManager.cpp" />
     <ClCompile Include="TextureCacheBase.cpp" />
@@ -165,6 +166,7 @@
     <ClInclude Include="SamplerCommon.h" />
     <ClInclude Include="ShaderGenCommon.h" />
     <ClInclude Include="Statistics.h" />
+    <ClInclude Include="SurfaceChangeInterlock.h" />
     <ClInclude Include="GeometryShaderGen.h" />
     <ClInclude Include="GeometryShaderManager.h" />
     <ClInclude Include="TextureCacheBase.h" />


### PR DESCRIPTION
Here are the minimum changes necessary to add my interlocking mechanism.

I'm skeptical that pausing the emulator or switching to headless is necessary, although i suppose it mitigates the chance of a deadlock if something goes wrong in waiting for the emuthread to destroy the surface or in the compositor for the surface creation event.

Either way, I'm curious to know if this works in your environment with minimal main/fullscreen changeover delays. It definitely seems to restore Qt's flexibility for Wayland, except for the client-side decorations.